### PR TITLE
Allows to pass ajax options to nmModal() using option ajax

### DIFF
--- a/js/jquery.nyroModal.filters.form.js
+++ b/js/jquery.nyroModal.filters.form.js
@@ -24,13 +24,17 @@ jQuery(function($, undefined) {
 				});
 			},
 			load: function(nm) {
-				var data = nm.opener.serializeArray();
+				var data = {};
+				$.map(nm.opener.serializeArray(), function(d){
+					data[d.name] = d.value;
+				});
 				if (nm.store.form.sel)
-					data.push({name: nm.selIndicator, value: nm.store.form.sel.substring(1)});
-				$.ajax({
+					data[nm.selIndicator] = nm.store.form.sel.substring(1);
+
+				var ajax = $.extend(true, { type : 'get', dataType : 'text' }, nm.ajax || {}, {
 					url: nm.store.form.url,
 					data: data,
-					type: nm.opener.attr('method') ? nm.opener.attr('method') : 'get',
+					type: nm.opener.attr('method') ? nm.opener.attr('method') : undefined,
 					success: function(data) {
 						nm._setCont(data, nm.store.form.sel);
 					},
@@ -38,6 +42,8 @@ jQuery(function($, undefined) {
 						nm._error();
 					}
 				});
+
+				$.ajax(ajax);
 			}
 		}
 	});

--- a/js/jquery.nyroModal.filters.link.js
+++ b/js/jquery.nyroModal.filters.link.js
@@ -24,16 +24,18 @@ jQuery(function($, undefined) {
 				});
 			},
 			load: function(nm) {
-				$.ajax({
-					url: nm.store.link.url,
-					data: nm.store.link.sel ? [{name: nm.selIndicator, value: nm.store.link.sel.substring(1)}] : undefined,
-					success: function(data) {
-						nm._setCont(data, nm.store.link.sel);
-					},
-					error: function() {
-						nm._error();
-					}
-				});
+				var ajax = $.extend(true, {}, nm.ajax || {}, {
+						url: nm.store.link.url,
+						data: nm.store.link.sel ? [{name: nm.selIndicator, value: nm.store.link.sel.substring(1)}] : undefined,
+						success: function(data) {
+							nm._setCont(data, nm.store.link.sel);
+						},
+						error: function() {
+							nm._error();
+						}
+					});
+
+				$.ajax(ajax);
 			}
 		}
 	});


### PR DESCRIPTION
Issues faced:
    Needed an option to pass the `dataType` option to the ajax request
    Needed an option to pass some custom `data` to the ajax request
    Needed an option to pass the request `type` to the ajax requst

If the ajax `dataType` option is overriden to `json` using http://api.jquery.com/jQuery.ajaxSetup/ then all attempts to load nyroModal with ajax contents fails.

Changes in both link and form filters to allow the additional option `ajax`.

Usage:

```
$('#manual1').click(function(e) {
    e.preventDefault();
    $.nmManual('demoSent.php', {
        ajax: {
            data: {
                myparam: "one"
            },
            type: "POST",
            dataType: "text"
        }
    });
});
```
