### PR TITLE
Replaced $.curCSS with $.css

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>nyroModal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/js/jquery.nyroModal.js
+++ b/js/jquery.nyroModal.js
@@ -664,7 +664,7 @@ jQuery(function($, undefined) {
 				this.fullSize.viewH = Math.min(this.fullSize.h, this.fullSize.wH);
 			},
 			_getCurCSS: function(elm, name) {
-				var ret = parseInt($.curCSS(elm, name, true));
+				var ret = parseInt($.css(elm, name, true));
 				return isNaN(ret) ? 0 : ret;
 			},
 			_getOuter: function(elm) {


### PR DESCRIPTION
Replaced $.curCSS with $.css. This is for compatibility with jQuery 1.8.x. Per [ticket #11787](http://bugs.jquery.com/ticket/11787), the $.curCSS was deprecated in jQuery 1.3 and removed entirely from jQuery 1.8.
